### PR TITLE
Adds an explicit requirement of the 'set' dependency.

### DIFF
--- a/lib/innertube.rb
+++ b/lib/innertube.rb
@@ -1,4 +1,5 @@
 require 'thread'
+require 'set'
 
 # Innertube is a re-entrant thread-safe resource pool that was
 # extracted from the Riak Ruby Client


### PR DESCRIPTION
The lack of "require 'set'" was not a problem when innertube was used in rails
or tested with RSpec, because 'set' is already loaded by those frameworks by the
time innertube can be initialized. It was only a problem in Ruby projects that
didn't happen to already load 'set' before using innertube.
