### PR TITLE
do not ship .gitignore in gem

### DIFF
--- a/innertube.gemspec
+++ b/innertube.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
 
   # Files
   ignores = File.read(".gitignore").split(/\r?\n/).reject{ |f| f =~ /^(#.+|\s*)$/ }.map {|f| Dir[f] }.flatten
-  gem.files = (Dir['**/*','.gitignore'] - ignores).reject {|f| !File.file?(f) }
-  gem.test_files = (Dir['spec/**/*','.gitignore'] - ignores).reject {|f| !File.file?(f) }
+  gem.files = (Dir['**/*'] - ignores).reject {|f| !File.file?(f) }
+  gem.test_files = (Dir['spec/**/*'] - ignores).reject {|f| !File.file?(f) }
   gem.require_paths = ['lib']
 end


### PR DESCRIPTION
This pull request remove the `.gitignore` file from the file lists in the gemspec.
