### PR TITLE
travis: remove deprecated Rubinius versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,7 @@ rvm:
   - jruby-18mode
   - jruby-19mode
   - jruby-head
-  - rbx-18mode
-  - rbx-19mode
+  - rbx-2
 notifications:
   webhooks: http://basho-engbot.herokuapp.com/travis?key=1a82cecc77a022b306b33d937403c8513578d1f3
   email: false


### PR DESCRIPTION
`rbx-18mode` and `rbx-19mode` are deprecated. Remove them in favor of Rubinius 2.