### PR TITLE
Fixes a deadlock condition

### DIFF
--- a/lib/innertube.rb
+++ b/lib/innertube.rb
@@ -164,7 +164,7 @@ module Innertube
       @iterator.synchronize do
         until targets.empty?
           @lock.synchronize do
-            @element_released.wait(@iterator) if targets.all? {|e| e.locked? }
+            @element_released.wait(@lock) if targets.all? {|e| e.locked? }
             unlocked, targets = targets.partition {|e| e.unlocked? }
             unlocked.each {|e| e.lock }
           end


### PR DESCRIPTION
...between `#each_element` and the `rescue` block in `#take`.

This happens when `#each_element` acquires `@lock` and waits on the `@element_released` condition variable to be signaled, but `#take` needs to acquire that same lock before signaling to that condition variable. This wait now releases `@lock` (instead of `@iterator`, which did not need to be released) so that `@element_released` can be signaled in the `ensure` block of `#take`.

This issue can be reliably reproduced by running the following code.

``` ruby
require 'innertube'
@pool = Innertube::Pool.new(
  proc { nil },
  proc { nil }
)
Thread.new do
  loop { @pool.each_element { nil } }
end
loop { @pool.take { fail Innertube::Pool::BadResource } rescue nil }
```

which produces the following result:

```
/Users/angelman/.rvm/gems/ruby-2.0.0-p648/gems/innertube-1.1.0/lib/innertube.rb:89:in `synchronize': No live threads left. Deadlock? (fatal)
    from /Users/angelman/.rvm/gems/ruby-2.0.0-p648/gems/innertube-1.1.0/lib/innertube.rb:89:in `delete_element'
    from /Users/angelman/.rvm/gems/ruby-2.0.0-p648/gems/innertube-1.1.0/lib/innertube.rb:140:in `rescue in take'
    from /Users/angelman/.rvm/gems/ruby-2.0.0-p648/gems/innertube-1.1.0/lib/innertube.rb:148:in `take'
    from deadlock.rb:10:in `block in <main>'
    from deadlock.rb:10:in `loop'
    from deadlock.rb:10:in `<main>'
```
